### PR TITLE
Set the id attribute on the card when it is the only one on the page

### DIFF
--- a/dist/client.bundle.js
+++ b/dist/client.bundle.js
@@ -400,12 +400,16 @@ var Card = function Card(props) {
   var q = (0, _qs.parse)(window.location.search, { ignoreQueryPrefix: true });
   var flat = q.flat === "true" || q.flat === "1";
   var flatStyle = '';
+  var id = null;
   if (flat) {
     flatStyle = 'flat ';
+    if (props.title || props.doc) {
+      id = 'card';
+    }
   }
   return _react2.default.createElement(
     'div',
-    { className: "reactcards-card " + flatStyle + _style2.default.card },
+    { id: id, className: "reactcards-card " + flatStyle + _style2.default.card },
     props.title ? _react2.default.createElement(
       CardHeader,
       null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactcards",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "devcards for react",
   "license": "BSD-3-Clause",
   "main": "dist/client.bundle.js",

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -10,11 +10,15 @@ const Card = (props) => {
   let q = parse(window.location.search, { ignoreQueryPrefix: true });
   let flat = q.flat === "true" || q.flat === "1";
   let flatStyle = '';
+  let id = null;
   if (flat) {
     flatStyle = 'flat ';
+    if (props.title || props.doc) {
+      id = 'card';
+    }
   }
   return (
-  <div className={"reactcards-card "+flatStyle +style.card}>
+  <div id={id} className={"reactcards-card "+flatStyle +style.card}>
   {props.title ? <CardHeader>{props.title}</CardHeader> : null}
   {props.doc ? <Markdown className={style.markdownDoc}>{props.doc}</Markdown> : null}
   {props.children}


### PR DESCRIPTION
The idea behind this change is that automated tests use the flat parameter, and automated tests could benefit from having a simple element ID to find the card under test.  This ID can easily be used to ensure the card is loaded and to capture just the specific element under test instead of the entire page